### PR TITLE
Update readme example code to match gif demo; remove Spinner green prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,15 +13,16 @@ $ npm install ink-spinner
 ## Usage
 
 ```js
-import React from 'react';
+import React, {Fragment} from 'react';
 import {render, Color} from 'ink';
 import Spinner from 'ink-spinner';
 
-render((
-	<Color green>
-		<Spinner green/>{' '}Loading
-	</Color>
-));
+render(
+	<Fragment>
+		<Color green><Spinner type="dots"/></Color>
+		{' Loading'}
+	</Fragment>
+);
 ```
 
 <img src="media/demo.gif" width="482">


### PR DESCRIPTION
The readme example code uses an extraneous `green` prop on the `Spinner` which doesn't do anything.

Since the entire example is wrapped in a `<Color green>`, the gif example doesn't match what the code actually does.

This PR adds an explicit prop `type="dots"` to make it explicit how to manipulate this component.
It also re-arranges the code so that only the `Spinner` gets the green treatment.