### PR TITLE
Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions ported from DefinitelyTyped
+// Ported by: M4rk9696 <https://github.com/M4rk9696>
+// Original Definitions by: Łukasz Ostrowski <https://github.com/lukostry>
+
+import { Chalk } from 'chalk';
+import * as cliSpinners from 'cli-spinners';
+import { Component } from 'react';
+
+type StringifyPartial<T> = {
+    [P in keyof T]?: string;
+};
+
+type BooleansPartial<T> = {
+    [P in keyof T]?: boolean;
+};
+
+type TupleOfNumbersPartial<T> = {
+    [P in keyof T]?: [number, number, number];
+};
+// Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+type ChalkColorModels = Pick<Chalk, 'rgb' | 'hsl' | 'hsv' | 'hwb' | 'bgRgb' | 'bgHsl' | 'bgHsv' | 'bgHwb'>;
+type ChalkKeywordsAndHexes = Pick<Chalk, 'keyword' | 'hex' | 'bgKeyword' | 'bgHex'>;
+type ChalkCommons = Omit<Chalk, keyof ChalkColorModels | keyof ChalkKeywordsAndHexes | 'constructor' | 'level' | 'enabled'>;
+
+interface SpinnerProps {
+    type?: cliSpinners.SpinnerName;
+}
+
+type ChalkProps = BooleansPartial<ChalkCommons>
+    & StringifyPartial<ChalkKeywordsAndHexes>
+    & TupleOfNumbersPartial<ChalkColorModels>;
+
+declare class Spinner extends Component<SpinnerProps & ChalkProps> { }
+
+export = Spinner;

--- a/index.test-d.tsx
+++ b/index.test-d.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import Spinner = require(".");
+import { render } from "ink";
+
+render(
+	<>
+		<Spinner type="dots" />
+		<Spinner green italic />
+		<Spinner hex="#fefefe" />
+		<Spinner rgb={[255, 100, 2]} />
+	</>
+);

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
 	},
 	"scripts": {
 		"pretest": "npm run build",
-		"test": "xo && ava",
+		"test": "xo && ava && tsd",
 		"build": "babel src --out-dir=build",
 		"prepare": "npm run build"
 	},
+	"types": "index.d.ts",
 	"files": [
-		"build"
+		"build",
+		"index.d.ts"
 	],
 	"keywords": [
 		"ink",
@@ -33,7 +35,7 @@
 		"react"
 	],
 	"dependencies": {
-		"cli-spinners": "^1.0.0",
+		"cli-spinners": "^2.2.0",
 		"prop-types": "^15.5.10"
 	},
 	"devDependencies": {
@@ -49,6 +51,7 @@
 		"ink": "^2.0.0",
 		"ink-testing-library": "^1.0.0",
 		"react": "^16.8.2",
+		"tsd": "^0.11.0",
 		"xo": "*"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"scripts": {
 		"pretest": "npm run build",
-		"test": "xo && ava && tsd",
+		"test": "xo && ava && tsc --noEmit --jsx react index.test-d.ts",
 		"build": "babel src --out-dir=build",
 		"prepare": "npm run build"
 	},
@@ -54,7 +54,7 @@
 		"ink": "^2.0.0",
 		"ink-testing-library": "^1.0.0",
 		"react": "^16.8.2",
-		"tsd": "^0.11.0",
+		"typescript": "^3.9.5",
 		"xo": "^0.32.0"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
Porting types from `DefinitelyTyped` to this repo as suggested in #6 

**Notes:**
- I had to update `cli-spinners` as TypeDefinitions are present only from to v2.
- Added `tsd` to verify types similar to the main `ink` repo

cc\ @vadimdemedes 