### PR TITLE
fixed bug where cli-spinners imported incorrectly

### DIFF
--- a/source/index.tsx
+++ b/source/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {useState, useEffect} from 'react';
 import type {FC} from 'react';
 import {Text} from 'ink';
-import * as spinners from 'cli-spinners';
+import spinners from 'cli-spinners';
 import type {SpinnerName} from 'cli-spinners';
 
 interface Props {


### PR DESCRIPTION
Previously `cli-spinners` was imported like this `import * as spinners from 'cli-spinners';`, which resulted in importing:

```typescript
{
  default: {
    // spinners here
  }
}
```

This made `ink-spinners` not work. Now it works.