### PR TITLE
Remove $ from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Looking for a version compatible with Ink 2.x? Check out [this release](https://
 ## Install
 
 ```
-$ npm install ink-spinner
+npm install ink-spinner
 ```
 
 ## Usage


### PR DESCRIPTION
Including the `$` shell prompt means it is also copied when you click the "copy" button on the codeblock.